### PR TITLE
fix: Keep search params on locale redirect.

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -21,7 +21,7 @@ export function middleware(req: NextRequest) {
     !languages.some(loc => req.nextUrl.pathname.startsWith(`/${loc}`)) &&
     !req.nextUrl.pathname.startsWith('/_next')
   ) {
-    return NextResponse.redirect(new URL(`/${lng}${req.nextUrl.pathname}`, req.url))
+    return NextResponse.redirect(new URL(`/${lng}${req.nextUrl.pathname}${req.nextUrl.search}`, req.url))
   }
 
   if (req.headers.has('referer')) {


### PR DESCRIPTION
When coming from an url that doesn't have a locale but that have some searchParams, the middleware would strip the search params when redirecting to the detected locale. 

for example, http://localhost:3000?searchParam=1 would redirect to http://localhost:3000/en

This PR fixes the issues by appending the search params to the redirect.